### PR TITLE
remove unused variable simple_pdg

### DIFF
--- a/larsimrad/BxDecay0/Decay0Gen_module.cc
+++ b/larsimrad/BxDecay0/Decay0Gen_module.cc
@@ -143,7 +143,7 @@ namespace evgen{
 
             double mass = bxdecay0::particle_mass_MeV(p.get_code());
             int pdg=0;
-            int simple_pdg=0;
+            //int simple_pdg=0; // simple_pdg is unused here
 
             if      (p.is_alpha   ()) { pdg = 1000020040; part = simb::MCParticle(track_id, pdg, primary_str,-1,mass,1); }
             else if (p.is_gamma   ()) { pdg =         22; part = simb::MCParticle(track_id, pdg, primary_str); }

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -6,7 +6,7 @@ defaultqual	e19
 fcldir  product_dir job
 #
 product         version
-larsim          v08_12_00
+larsim          v08_29_00
 bxdecay0	v1_0_5
 cetbuildtools   v7_15_01    -   only_for_build
 end_product_list


### PR DESCRIPTION
This PR can be used to investigate problems found when building with clang.